### PR TITLE
issue/196 - add cancel reserved link in email

### DIFF
--- a/app/mailers/reserve_mailer.rb
+++ b/app/mailers/reserve_mailer.rb
@@ -3,11 +3,12 @@
 class ReserveMailer < ApplicationMailer
   def reserve_notify(reservation)
     @reservation = reservation
-
-    # qr = RQRCode::QRCode.new("#{ENV['WEB_DOMAIN']}/backstage/reservations/#{reservation.id}/qrscan", size: 10, level: :h)
-    qr = RQRCode::QRCode.new("http://localhost:3000/backstage/reservations/#{reservation.id}/qrscan", size: 10,
-                                                                                                      level: :h)
-
+    # @cancel_url = "http://localhost:3000/reservations/#{reservation.serial}/cancel"
+    @cancel_url = "#{ENV['WEB_DOMAIN']}/reservations/#{reservation.serial}/cancel"
+    
+    # qr = RQRCode::QRCode.new("http://localhost:3000/backstage/reservations/#{reservation.id}/qrscan", size: 10, level: :h)    
+    qr = RQRCode::QRCode.new("#{ENV['WEB_DOMAIN']}/backstage/reservations/#{reservation.id}/qrscan", size: 10, level: :h)    
+    
     png = qr.as_png(
       bit_depth: 1,
       border_modules: 4,

--- a/app/views/reserve_mailer/reserve_notify.html.erb
+++ b/app/views/reserve_mailer/reserve_notify.html.erb
@@ -29,3 +29,7 @@
 <h2>到店給店員掃描的QRCODE</h2>
 <%= image_tag(attachments['qr.png'].url)%>
 
+<h2>取消訂位</h2>
+<button style="padding: 5px 20px; background-color: #FB8500; border: 1px solid #FB8500; border-radius: 15px;">
+  <a href=<%= @cancel_url %> style="color: white; text-decoration: none;">點我取消訂位</a>
+</button>


### PR DESCRIPTION
信件裡面增加取消訂位的按鈕
PS. code那邊我有留著localhost的註解，想要在本地端測試的時候可以直接打開用

<img width="902" alt="截圖 2023-01-02 下午10 10 42" src="https://user-images.githubusercontent.com/27533334/210243557-9bd5fd84-635b-4b5e-ad3c-5deb5a4b316c.png">
